### PR TITLE
Abort further execution on keychain file load fail

### DIFF
--- a/src/keychain.js
+++ b/src/keychain.js
@@ -126,7 +126,10 @@ Keychain.prototype.load = function (keychainPath, callback) {
 
   var self = this;
   fs.readdir(this.profileFolder, function (err, folderContents) {
-    if (err != null) { callback(err); }
+    if (err != null) {
+      callback(err);
+      return;
+    }
 
     var profile = null;
     var folders = null;


### PR DESCRIPTION
When loading an invalid path etc, 1passwordjs will call the callback with a error as it's supposed to, but then still attempt to loop over `folderContents`, which will throw a TypeError because `folderContents` is obviously `undefined`.